### PR TITLE
Fixed issue when the USB is connected and it does fast updates

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,8 +9,8 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [common]
-version = "v0.2"
-revision = 47
+version = "v0.3"
+revision = 49
 
 [env:M5COREINK]
 platform = espressif32
@@ -25,7 +25,7 @@ build_flags =
     -D REVISION="${common.revision}"
 
 lib_deps =
-	hpsaturn/CanAirIO Air Quality Sensors Library @ ^0.5.3
+	hpsaturn/CanAirIO Air Quality Sensors Library @ ^0.5.5
     https://github.com/ZinggJM/GxEPD2.git
     https://github.com/hpsaturn/M5-CoreInk.git#fix_inkEnable_issue
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,7 @@
 
 #define DEEP_SLEEP_MODE       1     // eInk and esp32 hibernate support (recommended)
 #define DEEP_SLEEP_TIME     600     // 600s (10m) or more (battery saving)
-#define SLEEP_USB_TIME        5     // 5s when the USB is connected
+#define SLEEP_USB_TIME       15     // 15s when the USB is connected or DEEP_SLEEP_MODE is 0
 #define BEEP_ENABLE           1     // Eneble AQI high level alarm:
 #define PM25_ALARM_BEEP     150     // PM2.5 level to trigger alarm
 #define CO2_ALARM_BEEP     2500     // CO2 ppm level to trigger alarm
@@ -264,10 +264,11 @@ void shutdown() {
         display.powerOff();
         M5.shutdown(DEEP_SLEEP_TIME);
         Serial.println("-->[LOOP] USB is connected..");
-        isCharging = true;  // it only is reached when the USB is connected
-        Serial.println("-->[LOOP] Simulate sleep");
-        delay(SLEEP_USB_TIME*1000);
+        isCharging = true;  
     }
+    // this only is reached when the USB is connected
+    Serial.println("-->[LOOP] Simulate sleep");
+    delay(SLEEP_USB_TIME*1000);
 }
 
 /// sensors callback, here we can get the values

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,8 @@
 #include <Sensors.hpp>
 
 #define DEEP_SLEEP_MODE       1     // eInk and esp32 hibernate support (recommended)
-#define DEEP_SLEEP_TIME     600     // *** !! Please change it !! *** to 600s (10m) or more 
+#define DEEP_SLEEP_TIME     600     // 600s (10m) or more (battery saving)
+#define SLEEP_USB_TIME        5     // 5s when the USB is connected
 #define BEEP_ENABLE           1     // Eneble AQI high level alarm:
 #define PM25_ALARM_BEEP     150     // PM2.5 level to trigger alarm
 #define CO2_ALARM_BEEP     2500     // CO2 ppm level to trigger alarm
@@ -264,7 +265,8 @@ void shutdown() {
         M5.shutdown(DEEP_SLEEP_TIME);
         Serial.println("-->[LOOP] USB is connected..");
         isCharging = true;  // it only is reached when the USB is connected
-        Serial.println("-->[LOOP] Deep sleep done.");
+        Serial.println("-->[LOOP] Simulate sleep");
+        delay(SLEEP_USB_TIME*1000);
     }
 }
 


### PR DESCRIPTION
## Description

To preserve the eInk display life, when the USB was connected the refresh time was very fast, with this fix it set to 15s